### PR TITLE
add wait db script to entrypoint

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+set -e
+
+bash scripts/tcp-port-wait.sh $DATABASE_HOST $DATABASE_PORT
+
 python manage.py migrate
 
 gunicorn products_service.wsgi --config products_service/gunicorn_conf.py


### PR DESCRIPTION
# Purpose
We need to update entrypoint to wait for db. Otherwise, it doesn't run migrations when db is not there.