### PR TITLE
 PLAT-327: Deploy swagger schema and README file to Docsite

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -40,3 +40,47 @@ pipeline:
       event: [push, tag]
       branch: [master]
       status: [success]
+
+  deploy-docs:
+    image: python:3.6
+    commands:
+      - bash scripts/tcp-port-wait.sh $${DATABASE_HOST} $${DATABASE_PORT}
+      - pip install -r requirements/base.txt
+      - python manage.py generate_swagger > swagger.json
+      - eval "$(ssh-agent -s)"
+      - mkdir -p /root/.ssh
+      - echo "$${SSH_KEY}\n" > /root/.ssh/id_rsa
+      - echo "$${SSH_PUBLIC_KEY}\n" > /root/.ssh/id_rsa.pub
+      - ssh-keyscan -t rsa github.com >> /root/.ssh/known_hosts
+      - chmod 600 /root/.ssh/id_rsa*
+      - ssh-add -k /root/.ssh/id_rsa
+      - git config --global user.email "engine@humanitec.com"
+      - git config --global user.name "HumanitecBot"
+      - git clone git@github.com:Humanitec/docs-site.git
+      - mkdir -p docs-site/hugo/content/marketplace/products-module/products-service/
+      - mkdir -p docs-site/hugo/static/marketplace/products-module/products-service/
+      - cd docs-site/hugo/content/marketplace/products-module/products-service/
+      - cp ../../../../../../README.md _index.md -r
+      - cd ../../../../static/marketplace/products-module/products-service/
+      - cp ../../../../../../swagger.json swagger.json -r
+      - cd ../../../../..
+      - git add .
+      - git commit -m "Updated documentation for Products service"
+      - git push origin master
+    environment:
+      - AWS_ACCESS_KEY_ID=example
+      - AWS_SECRET_ACCESS_KEY=example
+      - AWS_STORAGE_BUCKET_NAME=example
+      - DATABASE_ENGINE=postgresql
+      - DATABASE_NAME=db
+      - DATABASE_USER=root
+      - DATABASE_PASSWORD=root
+      - DATABASE_HOST=postgres
+      - DATABASE_PORT=5432
+      - DJANGO_SETTINGS_MODULE=products_service.settings.base
+      - SECRET_KEY=nothing
+    secrets: [NPM_USER, NPM_EMAIL, SSH_KEY, SSH_PUBLIC_KEY]
+    when:
+      event: [push, tag]
+      branch: [master]
+      status: [success]

--- a/products_service/settings/base.py
+++ b/products_service/settings/base.py
@@ -177,3 +177,8 @@ AWS_SECRET_ACCESS_KEY = os.getenv('AWS_ACCESS_KEY_SECRET')
 AWS_STORAGE_BUCKET_NAME = os.getenv('AWS_STORAGE_BUCKET_NAME')
 AWS_S3_SECURE_URLS = True
 AWS_DEFAULT_ACL = None
+
+# Swagger settings - for generate_swagger management command
+SWAGGER_SETTINGS = {
+    'DEFAULT_INFO': 'products_service.urls.swagger_info',
+}

--- a/products_service/urls.py
+++ b/products_service/urls.py
@@ -24,12 +24,14 @@ from products import views
 from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
 
-schema_view = get_schema_view(
-    openapi.Info(
+swagger_info = openapi.Info(
         title="Products Service API",
         default_version='latest',
         description="Test description",
-    ),
+)
+
+schema_view = get_schema_view(
+    swagger_info,
     public=True,
     permission_classes=(permissions.AllowAny,),
 )


### PR DESCRIPTION
## Purpose

We need to push swagger schema file and readme file to docs-site repo.

## Approach

In drone: generate swagger schema file, then clone docs-site repo, add and commit these files.
The result: https://github.com/Humanitec/docs-site/commit/238415a53731de95adbd9d50293a8c2cd28d5362