### PR TITLE
PLAT-327: check diff before commiting to the docs site

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -65,7 +65,7 @@ pipeline:
       - cp ../../../../../../swagger.json swagger.json -r
       - cd ../../../../..
       - git add .
-      - git commit -m "Updated documentation for Products service"
+      - git diff-index --quiet HEAD || git commit -m "Updated documentation for Products service"
       - git push origin master
     environment:
       - AWS_ACCESS_KEY_ID=example


### PR DESCRIPTION
## Purpose

When none of swagger.json or readme.md changed, drone deploy-docs fails with ```nothing to commit, working tree clean``` error.

## Approach

To fix it first check the diff