### PR TITLE
WAL-154 - Update drone file with new registry structure

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -30,14 +30,19 @@ pipeline:
 
   build-docker-image-tag:
     image: plugins/docker
-    insecure: true
-    registry: registry.tola.io
-    repo: registry.tola.io/humanitec-walhall/products_service
-    file: Dockerfile
+    registry:
+      from_secret: DOCKER_REGISTRY
+    repo:
+      from_secret: DOCKER_REPO
+    username:
+      from_secret: DOCKER_USERNAME
+    password:
+      from_secret: DOCKER_PASSWORD
     auto_tag: true
-    secrets: [DOCKER_USERNAME, DOCKER_PASSWORD]
+    insecure: true
+    file: Dockerfile
     when:
-      event: [push, tag]
+      event: [tag]
       branch: [master]
       status: [success]
 


### PR DESCRIPTION
## Purpose
We should stop using "Humanitec-Walhall" registry and restructure the docker registry to use organization names as folders.