### PR TITLE
Add category_display and subcategory_display

### DIFF
--- a/products/serializer.py
+++ b/products/serializer.py
@@ -8,6 +8,20 @@ from . import models
 class ProductSerializer(serializers.ModelSerializer):
     replaced_product = serializers.PrimaryKeyRelatedField(queryset=models.Product.objects.all(), required=False,
                                                           allow_null=True)
+    category_display = serializers.SerializerMethodField(method_name='get_root_category_display')
+    subcategory_display = serializers.SerializerMethodField(method_name='get_level1_category_display')
+
+    def get_root_category_display(self, obj):
+        if obj.category:
+            if getattr(obj.category, 'parent', None):
+                return obj.category.parent.name
+            return obj.category.name
+        return None
+
+    def get_level1_category_display(self, obj):
+        if obj.category and getattr(obj.category, 'parent', None):
+            return obj.category.name
+        return None
 
     def to_representation(self, instance):
         # replace direct file link with file entry point URL

--- a/products/tests/test_serializers.py
+++ b/products/tests/test_serializers.py
@@ -4,10 +4,11 @@ from django.test import TestCase
 from rest_framework.test import APIRequestFactory
 
 from . import model_factories
-from ..serializer import CategorySerializer, RootCategorySerializer
+from ..serializer import CategorySerializer, RootCategorySerializer, ProductSerializer
 
 
-class ProductCategorySerializerTest(TestCase):
+class ProductSerializerBaseTest(TestCase):
+
     def setUp(self):
         self.factory = APIRequestFactory()
         self.user = model_factories.User()
@@ -15,6 +16,9 @@ class ProductCategorySerializerTest(TestCase):
         self.session = {
             'jwt_organization_uuid': self.organization_uuid,
         }
+
+
+class ProductCategorySerializerTest(ProductSerializerBaseTest):
 
     def test_categoryserializer_keys(self):
         product_category = model_factories.CategoryFactory()
@@ -27,3 +31,37 @@ class ProductCategorySerializerTest(TestCase):
         serializer = RootCategorySerializer(product_category)
         keys = ['uuid', 'children', 'name', 'is_global', 'create_date', 'edit_date', 'level', 'parent', ]
         self.assertEqual(list(serializer.data.keys()), keys)
+
+
+class ProductSerializerTest(ProductSerializerBaseTest):
+
+    def test_category_display_none(self):
+        product = model_factories.Product()
+        serializer = ProductSerializer(product)
+        self.assertEqual(serializer.data['category_display'], None)
+
+    def test_category_display(self):
+        # category without parent
+        product_category = model_factories.CategoryFactory(name='test-without-parent')
+        product = model_factories.Product(category=product_category)
+        serializer = ProductSerializer(product)
+        self.assertEqual(serializer.data['category_display'], product_category.name)
+        # category with parent
+        product_category_parent = model_factories.CategoryFactory(name='test-with-parent')
+        product_category.parent = product_category_parent
+        product_category.save()
+        serializer = ProductSerializer(product)
+        self.assertEqual(serializer.data['category_display'], product_category_parent.name)
+
+    def test_subcategory_display(self):
+        product_category_parent = model_factories.CategoryFactory(name='test-root')
+        product_subcategory = model_factories.CategoryFactory(name='test-subcategory',
+                                                              parent=product_category_parent)
+        product = model_factories.Product(category=product_subcategory)
+        serializer = ProductSerializer(product)
+        self.assertEqual(serializer.data['subcategory_display'], product_subcategory.name)
+        # test None
+        product.category = product_category_parent
+        product.save()
+        serializer = ProductSerializer(product)
+        self.assertEqual(serializer.data['subcategory_display'], None)


### PR DESCRIPTION
For faster lookups and not needing to extra-query and loop through the categories when showing the products, these 2 read-only fields are required.